### PR TITLE
fix to avoid creating game directories with empty launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This Python script automates the installation of games for Lindbergh systems on 
 | The House of the Dead 4 (Rev A) | hotd4      | hotd4.bin                         | elf               | ext2       |
 | The House of the Dead 4 Special | hotd4sp    | hotd4sp.bin                       | elf               | ext2       |
 | The House of the Dead EX        | hotdex     | hotd4ex.bin                       | elf               | ext2       |
-| Hummer Extreme Edition          | hummerxt   | hummer.bin                        | elf               | ext2       |
+| Hummer Extreme Edition          | hummerxt   | hummer.bin                        |                   | ext2       |
 | Initial D Arcade Stage 4 (Rev B)| initiad4b  | id4.bin                           |                   | ext2       |
 | Initial D 4 (Export) (Rev D)    | initiad4ex | id4exp.bin                        |                   | ext2       |
 | Initial D 5 (Export) (2.0)      | initiad5exa| initiald5.bin, id5_data.bin       | data              | ext3       |

--- a/games_config.yml
+++ b/games_config.yml
@@ -79,7 +79,7 @@ hotdex:
 # Hummer Extreme Edition
 hummerxt:
   display_name: "Hummer Extreme Edition"
-  launcher_path: "elf"
+  launcher_path: ""
   filesystem: "ext2"
   steps:
     - file: "hummer.bin"

--- a/lindbergh_installer.py
+++ b/lindbergh_installer.py
@@ -136,20 +136,22 @@ def process_game(game_key, game_config):
 		print(f"{RED}The destination directory {dest_dir} already exists. Skipping game.{RESET}")
 		return
 
-	os.makedirs(dest_dir, exist_ok=True)
+	installFailure = False
 	steps = game_config.get("steps", [])
 	for step in steps:
-		process_step(step, dest_dir)
+		if not process_step(step, dest_dir):
+			installFailure = True
 
-	# Handle final move operations
-	final_moves = game_config.get("final_move", [])
-	if final_moves:
-		process_final_move(final_moves, dest_dir)
+	if not installFailure:
+		# Handle final move operations
+		final_moves = game_config.get("final_move", [])
+		if final_moves:
+			process_final_move(final_moves, dest_dir)
 
-	# Create the launcher file
-	create_launcher(game_key, game_config, dest_dir)
+		# Create the launcher file
+		create_launcher(game_key, game_config, dest_dir)
 
-	print(f"{GREEN}Installation completed for {game_config.get('display_name', game_key)}{RESET}")
+		print(f"{GREEN}Installation completed for {game_config.get('display_name', game_key)}{RESET}")
 
 def main():
 	CONFIG_FILE = "games_config.yml"


### PR DESCRIPTION
fix for #1 

appears to be working.  only tested use cases related to `all`:
1. an empty directory (no launchers are created)
2. existing roms directory (it doesn't clobber existing games and doesn't create new launchers)
3. existing roms directory with new .bin to install (installs game and skips the rest)
4. run script again immediately after install (before deleting `.bin`) and title just installed is skipped (effectively NOOP)
5. existing roms directory with two (2) .bin to install (installs both games and skips the rest)